### PR TITLE
Export GeoJSON and GeoPackage

### DIFF
--- a/delineate_sewershed.ipynb
+++ b/delineate_sewershed.ipynb
@@ -461,7 +461,7 @@
    "source": [
     "## Save results to files\n",
     "\n",
-    "Save results in a file:"
+    "Save sewershed as GeoJSON and GeoPackage:"
    ]
   },
   {
@@ -483,6 +483,13 @@
     ")\n",
     "# Other formats may work too, but notably, ESRI Shapefile will not because of its\n",
     "# limited column name length."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save computed demographics as CSV:"
    ]
   },
   {

--- a/delineate_sewershed.ipynb
+++ b/delineate_sewershed.ipynb
@@ -339,7 +339,14 @@
    "outputs": [],
    "source": [
     "from helpers import statistics_to_one_vector\n",
-    "statistics_to_one_vector(input_vector=sewershed_blocks, dissolve_column=dissolve_column, columns_to_aggregate=aggregate_columns, result_columns=result_columns, output=sewershed)"
+    "\n",
+    "statistics_to_one_vector(\n",
+    "    input_vector=sewershed_blocks,\n",
+    "    dissolve_column=dissolve_column,\n",
+    "    columns_to_aggregate=aggregate_columns,\n",
+    "    result_columns=result_columns,\n",
+    "    output=sewershed,\n",
+    ")"
    ]
   },
   {
@@ -463,10 +470,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = (\n",
-    "    Path(sewers_directory) / \"sewershed_with_demographics.shp\"\n",
-    ")  # Modify as needed.\n",
-    "gs.run_command(\"v.out.ogr\", input=sewershed_filled_holes, output=output_file)"
+    "base_name = \"sewershed_with_demographics\"  # Modify as needed.\n",
+    "# GeoJSON\n",
+    "output_file = Path(sewers_directory) / f\"{base_name}.json\"\n",
+    "gs.run_command(\n",
+    "    \"v.out.ogr\", input=sewershed_filled_holes, output=output_file, format=\"GeoJSON\"\n",
+    ")\n",
+    "# OGC GeoPackage\n",
+    "output_file = Path(sewers_directory) / f\"{base_name}.gpkg\"\n",
+    "gs.run_command(\n",
+    "    \"v.out.ogr\", input=sewershed_filled_holes, output=output_file, format=\"GPKG\"\n",
+    ")\n",
+    "# Other formats may work too, but notably, ESRI Shapefile will not because of its\n",
+    "# limited column name length."
    ]
   },
   {


### PR DESCRIPTION
Remove export of Shapefile because it does not work with long column names.

Fix formatting of aggregation code.
